### PR TITLE
style: fix rustfmt issues

### DIFF
--- a/src/renderer/engine.rs
+++ b/src/renderer/engine.rs
@@ -59,7 +59,7 @@ impl RenderEngine {
                 for layer in &layers {
                     self.render_layer(layer)?;
                 }
-                
+
                 // Flush GPU commands after rendering all layers
                 self.flush_gpu()?;
             }
@@ -83,7 +83,7 @@ impl RenderEngine {
                 // Placeholder: draw colored rectangle for image
                 let (x, y) = Compositor::apply_transform(0, 0, transform);
                 let color = [100, 100, 200, 255];
-                
+
                 if let Some(gpu) = &self.gpu_renderer {
                     gpu.fill_rect(&mut self.frame_buffer, x, y, 100, 100, color)?;
                 } else {
@@ -94,7 +94,7 @@ impl RenderEngine {
                 // Placeholder: draw colored rectangle for video
                 let (x, y) = Compositor::apply_transform(0, 0, transform);
                 let color = [200, 100, 100, 255];
-                
+
                 if let Some(gpu) = &self.gpu_renderer {
                     gpu.fill_rect(&mut self.frame_buffer, x, y, 100, 100, color)?;
                 } else {
@@ -208,7 +208,7 @@ mod tests {
         let script = create_test_script();
         let mut engine = RenderEngine::new(script);
         let mut asset_loader = AssetLoader::new(".");
-        
+
         // Should not panic even if GPU is not available (fallback to CPU)
         // If GPU is available, it exercises the flush() logic
         engine.render_frame(0, &mut asset_loader).unwrap();


### PR DESCRIPTION
### **User description**
Fixes formatting issues that caused CI failure in PR #9.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove trailing whitespace from multiple lines

- Reformat method chaining for improved readability

- Fix rustfmt formatting violations in GPU renderer

- Align code style with Rust formatting standards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Formatting Issues"] -->|Remove trailing whitespace| B["Clean whitespace"]
  A -->|Reformat method chains| C["Improved readability"]
  B --> D["CI compliance"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.rs</strong><dd><code>Remove trailing whitespace in render methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/engine.rs

<ul><li>Remove trailing whitespace from 4 lines in render methods<br> <li> Clean up blank lines after variable declarations<br> <li> Maintain code logic while fixing formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/wilkerHop/interstellar-triangulum/pull/10/files#diff-70e16208a576f624dcc1142054823e459cbb1ac513d1f52f130bbd6c1511e879">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gpu_renderer.rs</strong><dd><code>Reformat method chains and fix whitespace issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/gpu_renderer.rs

<ul><li>Reformat method chaining for <code>write_buffer</code> call<br> <li> Restructure <code>create_texture</code> call with improved indentation<br> <li> Reformat <code>create_command_encoder</code> call for readability<br> <li> Fix trailing whitespace and blank line formatting<br> <li> Reformat <code>poll</code> method call with proper line breaks</ul>


</details>


  </td>
  <td><a href="https://github.com/wilkerHop/interstellar-triangulum/pull/10/files#diff-a1e2d1b575c6c4e463a9d28a33930b099ebfb3b2e58319a73a51fb8f3f446744">+36/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

