### PR TITLE
ci: Add Apple Silicon (M1) Test Workflow

### DIFF
--- a/.github/workflows/apple-silicon-test.yml
+++ b/.github/workflows/apple-silicon-test.yml
@@ -52,3 +52,9 @@ jobs:
       # This runs the actual GPU rendering pipeline on the M1 runner
       run: |
         cargo run -- render examples/texture_test.json --renderer gpu --output output_texture_ci
+
+    - name: Upload Video Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: demo-video-AppleSilicon
+        path: output_texture_ci/frame_0.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,11 +217,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download Video Artifact
+      - name: Download Linux Video
         uses: actions/download-artifact@v4
         with:
           name: demo-video-Linux
-          path: video-artifact
+          path: video-linux
+
+      - name: Download macOS Video
+        uses: actions/download-artifact@v4
+        with:
+          name: demo-video-macOS
+          path: video-macos
+
+      - name: Download Windows Video
+        uses: actions/download-artifact@v4
+        with:
+          name: demo-video-Windows
+          path: video-windows
+
+      - name: Download Apple Silicon Image
+        # Note: Apple Silicon test produces an image frame, not a video yet
+        uses: actions/download-artifact@v4
+        continue-on-error: true # Optional, in case the other workflow hasn't finished
+        with:
+          name: demo-video-AppleSilicon
+          path: video-apple-silicon
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -230,7 +250,12 @@ jobs:
         run: |
           mkdir public
           cp index.html public/
-          mv video-artifact/output.mp4 public/
+          
+          # Copy artifacts if they exist
+          [ -f video-linux/output.mp4 ] && cp video-linux/output.mp4 public/output-linux.mp4
+          [ -f video-macos/output.mp4 ] && cp video-macos/output.mp4 public/output-macos.mp4
+          [ -f video-windows/output.mp4 ] && cp video-windows/output.mp4 public/output-windows.mp4
+          [ -f video-apple-silicon/frame_0.png ] && cp video-apple-silicon/frame_0.png public/output-apple-silicon.png
 
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3

--- a/index.html
+++ b/index.html
@@ -39,15 +39,60 @@
                 </p>
             </div>
 
-            <!-- Video Player -->
-            <div class="relative group rounded-2xl overflow-hidden shadow-2xl shadow-indigo-500/20 border border-slate-800 bg-slate-950 aspect-video">
-                <video controls autoplay loop muted class="w-full h-full object-contain">
-                    <source src="output.mp4" type="video/mp4">
-                    Your browser does not support the video tag.
-                </video>
-                
-                <!-- Overlay Gradient -->
-                <div class="absolute inset-0 pointer-events-none ring-1 ring-inset ring-white/10 rounded-2xl"></div>
+            <!-- CI Artifacts Grid -->
+            <div class="grid md:grid-cols-2 gap-8">
+                <!-- Linux Artifact -->
+                <div class="space-y-2">
+                    <h3 class="text-xl font-semibold text-indigo-400 flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+                        Linux (Ubuntu)
+                    </h3>
+                    <div class="relative group rounded-xl overflow-hidden shadow-lg shadow-indigo-500/10 border border-slate-800 bg-slate-950 aspect-video">
+                        <video controls loop muted class="w-full h-full object-contain">
+                            <source src="output-linux.mp4" type="video/mp4">
+                            Video not available
+                        </video>
+                    </div>
+                </div>
+
+                <!-- macOS Artifact -->
+                <div class="space-y-2">
+                    <h3 class="text-xl font-semibold text-purple-400 flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.21-1.96 1.07-3.11-1.05.05-2.31.71-3.06 1.58-.69.8-1.26 2.07-1.1 3.21 1.17.08 2.35-.85 3.09-1.68z"/></svg>
+                        macOS (Intel)
+                    </h3>
+                    <div class="relative group rounded-xl overflow-hidden shadow-lg shadow-purple-500/10 border border-slate-800 bg-slate-950 aspect-video">
+                        <video controls loop muted class="w-full h-full object-contain">
+                            <source src="output-macos.mp4" type="video/mp4">
+                            Video not available
+                        </video>
+                    </div>
+                </div>
+
+                <!-- Windows Artifact -->
+                <div class="space-y-2">
+                    <h3 class="text-xl font-semibold text-blue-400 flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M3 12V6.75L9 5.43V11.91L3 12M20 3V11.75L10 11.9V5.21L20 3M3 13L9 13.09V19.9L3 18.75V13M20 13.25V22L10 20.09V13.1L20 13.25Z"/></svg>
+                        Windows
+                    </h3>
+                    <div class="relative group rounded-xl overflow-hidden shadow-lg shadow-blue-500/10 border border-slate-800 bg-slate-950 aspect-video">
+                        <video controls loop muted class="w-full h-full object-contain">
+                            <source src="output-windows.mp4" type="video/mp4">
+                            Video not available
+                        </video>
+                    </div>
+                </div>
+
+                <!-- Apple Silicon Artifact -->
+                <div class="space-y-2">
+                    <h3 class="text-xl font-semibold text-pink-400 flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>
+                        Apple Silicon (M1)
+                    </h3>
+                    <div class="relative group rounded-xl overflow-hidden shadow-lg shadow-pink-500/10 border border-slate-800 bg-slate-950 aspect-video flex items-center justify-center">
+                         <img src="output-apple-silicon.png" alt="Apple Silicon Render" class="w-full h-full object-contain">
+                    </div>
+                </div>
             </div>
 
             <!-- Pillars Grid -->


### PR DESCRIPTION
### **User description**
Adds a dedicated CI workflow to test on Apple Silicon (M1) runners using `macos-14`. This ensures that Metal optimizations are verified on actual ARM64 hardware.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds dedicated CI workflow for Apple Silicon (M1) testing

- Verifies Metal GPU optimizations on ARM64 hardware

- Includes formatting, linting, tests, and GPU rendering validation

- Implements Cargo dependency caching for faster builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push/PR to main"] --> B["Checkout code"]
  B --> C["Install Rust toolchain"]
  C --> D["Cache Cargo dependencies"]
  D --> E["Format & Clippy checks"]
  E --> F["Run tests"]
  F --> G["Run benchmarks"]
  G --> H["Verify GPU texture rendering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apple-silicon-test.yml</strong><dd><code>Apple Silicon CI workflow with GPU rendering validation</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/apple-silicon-test.yml

<ul><li>Creates new CI workflow triggered on push and pull requests to main <br>branch<br> <li> Configures macOS 14 runner for Apple Silicon (M1) hardware testing<br> <li> Installs Rust toolchain with clippy and rustfmt components<br> <li> Implements Cargo caching strategy for registry, git, and build <br>artifacts<br> <li> Runs code formatting checks, clippy linting, and test suite<br> <li> Executes benchmarks and GPU texture rendering validation on M1 <br>hardware</ul>


</details>


  </td>
  <td><a href="https://github.com/wilkerHop/interstellar-triangulum/pull/61/files#diff-b072e446457e337ed57aeb24fff87969f6548d51d71c67512b576ce393d25582">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

